### PR TITLE
sprint and sound fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Create: BalancedFlight
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=2.4.3
+mod_version=2.4.4
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/hoc/balancedflight/mixins/ElytraMixin.java
+++ b/src/main/java/com/hoc/balancedflight/mixins/ElytraMixin.java
@@ -27,7 +27,6 @@ public class ElytraMixin
             if (!allowed.canElytraFly())
                 return;
 
-            player.startFallFlying();
             player.connection.send(new ServerboundPlayerCommandPacket(player, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
             ci.cancel();
         }

--- a/src/main/java/com/hoc/balancedflight/mixins/ElytraRocketShiftKeyMixin.java
+++ b/src/main/java/com/hoc/balancedflight/mixins/ElytraRocketShiftKeyMixin.java
@@ -4,6 +4,7 @@ package com.hoc.balancedflight.mixins;
 import com.hoc.balancedflight.content.flightAnchor.FlightController;
 import com.hoc.balancedflight.foundation.config.BalancedFlightConfig;
 import com.hoc.balancedflight.foundation.network.CustomNetworkMessage;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
@@ -29,12 +30,12 @@ public class ElytraRocketShiftKeyMixin
             if (!allowed.canElytraFly())
                 return;
 
-            if (player.isSprinting() && player.input.hasForwardImpulse())
+            if (Minecraft.getInstance().options.keySprint.isDown() && player.input.hasForwardImpulse())
             {
                 Level world = player.level();
 
-                long now = Instant.now().getEpochSecond();
-                if (now - LastUsedFireworkTime > 1)
+                long now = Instant.now().toEpochMilli();
+                if (now - LastUsedFireworkTime > 1000)
                 {
                     CustomNetworkMessage.Send(world, player, "FIRE_ROCKET");
                     LastUsedFireworkTime = now;


### PR DESCRIPTION
I changed the boost detection, so that you can now boost after you have stopped sprinting once. Also, the 1 second delay is now persistent.
There was a sound bug where the elytra flight sound played twice, sometimes with a few milliseconds delay, which sounded very weird.. (and also a bit loud). I removed the startFallFlying call on the client, which fixes this issue, but I'm not really sure if it breaks something. I tested it in sigleplayer and on a server and I could not see any issues with starting and stopping flight, the player model also behaves as normal. Maybe when the server receives the start falling packet, it also sends it back to this client... I can't really explain to me why this line was there in the first place.

Anyway this really bothered me the last time I played with this mod lol

(Btw I also recently created a modrinth page for my fork that had these changes, but it was rejected due to fork policies... I don't really understand why mine got rejected and yours didn't, but I guess I just add these changes here then xD)